### PR TITLE
Added verification for speed argument.

### DIFF
--- a/pngquant.go
+++ b/pngquant.go
@@ -2,13 +2,19 @@ package pngquant
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/png"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
 func Compress(input image.Image, speed string) (output image.Image, err error) {
+	if err = speedCheck(speed); err != nil {
+		return
+	}
+
 	var w bytes.Buffer
 	err = png.Encode(&w, input)
 	if err != nil {
@@ -37,5 +43,19 @@ func CompressBytes(input []byte, speed string) (output []byte, err error) {
 	}
 
 	output = o.Bytes()
+	return
+}
+
+func speedCheck(speed string) (err error) {
+	// conversion, as an aside, also forces the speed argument to be a number.
+	speedInt, err := strconv.Atoi(speed)
+	if err != nil {
+		return
+	}
+
+	if speedInt > 10 {
+		return fmt.Errorf("speed cannot exceed value of 10")
+	}
+
 	return
 }

--- a/pngquant_test.go
+++ b/pngquant_test.go
@@ -14,13 +14,28 @@ func TestCompress(t *testing.T) {
 	info, _ := file.Stat()
 	orgSize := info.Size()
 	orgImg, _ := png.Decode(file)
+
+	// Test with good data
 	newImg, err := Compress(orgImg, "1")
 	if err != nil {
 		t.Errorf("error has occurred: %v", err)
+	} else {
+		var w bytes.Buffer
+		png.Encode(&w, newImg)
+		if len(w.Bytes()) > int(orgSize) {
+			t.Error("image is not comppressed")
+		}
 	}
-	var w bytes.Buffer
-	png.Encode(&w, newImg)
-	if len(w.Bytes()) > int(orgSize) {
-		t.Error("image is not comppressed")
+
+	// Test with non-numerical data (no need to test encode as we expect nothing)
+	_, err = Compress(orgImg, "one")
+	if err == nil {
+		t.Errorf("ERROR: Expected failure on incompatible speed argument (one)")
+	}
+
+	// Test with number that exceeds the limit (no need to test encode as we expect nothing)
+	_, err = Compress(orgImg, "20")
+	if err == nil {
+		t.Errorf("ERROR: Expected failure on incompatible speed argument (20)")
 	}
 }


### PR DESCRIPTION
Checking the speed argument allows for better performance & feedback to the importing program, as we can detect errors before the command is executed.

Additionally, from a security perspective, we can also avoid malicious commands being inadvertently injected via the speed argument.

**Changes**:
- Added speedCheck function to sanity check the speed variable.
- Updated tests to ensure bad data is successfully rejected.